### PR TITLE
인사이트 저장 (정보, 이미지, mainImage) API 적용

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -17,6 +17,15 @@ const nextConfig = {
     });
     return config;
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**',
+        pathname: '**',
+      },
+    ],
+  },
 };
 
 export default PWA(nextConfig);

--- a/src/api/insight.ts
+++ b/src/api/insight.ts
@@ -52,7 +52,7 @@ export const useGetSummary = (link: string, folderList: string[]) => {
     queryFn: () => fetchSummary(link, folderList),
     enabled: !!link,
   });
-  console.log(data?.choices);
+  // console.log(data?.choices);
   const result = {
     title: data?.choices?.[0]?.message.content
       .split('요약:')[0]
@@ -67,7 +67,7 @@ export const useGetSummary = (link: string, folderList: string[]) => {
       .split('폴더명: ')[1]
       .split(','),
   };
-  console.log(result.folderName);
+  // console.log(result.folderName);
   return { isLoading, error, result };
 };
 

--- a/src/api/insight.ts
+++ b/src/api/insight.ts
@@ -4,8 +4,8 @@ import {
   FolderSearchTagGetResponse,
   FolderShareGetResponse,
   InsightGetResponse,
-  InsightOGImagePostRequest,
-  InsightOGImagePostResponse,
+  InsightOGImageGetRequest,
+  InsightOGImageGetResponse,
   InsightPostRequest,
   InsightPostResponse,
   InsightPutRequest,
@@ -118,10 +118,10 @@ export async function getFolderInsightByTag(
 }
 
 // 인사이트 링크 대표 이미지 제공
-export async function postInsightOGImage(
-  imageData: InsightOGImagePostRequest,
-): Promise<InsightOGImagePostResponse> {
-  const response = await api.post(`/insight/ogimage/${imageData.url}`);
+export async function getInsightOGImage(
+  url: InsightOGImageGetRequest,
+): Promise<InsightOGImageGetResponse> {
+  const response = await api.get(`/insight/ogimage?url=${url}`);
   return response.data;
 }
 

--- a/src/components/folder/UploadImage.tsx
+++ b/src/components/folder/UploadImage.tsx
@@ -3,10 +3,13 @@ import Image from 'next/image';
 import NoImage from '@svg/no-image-icon.svg';
 import DeleteImageIcon from '@svg/DeleteImageIcon';
 import AddImageIcon from '@svg/add-image-icon.svg';
+import { Dispatch, SetStateAction } from 'react';
 
 interface Props {
   imageList: string[];
   setImageList: (imageList: string[]) => void;
+  imageFiles: File[];
+  setImageFiles: Dispatch<SetStateAction<File[]>>;
 }
 
 const UploadImage = (props: Props) => {
@@ -17,19 +20,21 @@ const UploadImage = (props: Props) => {
     props.setImageList(newList);
   };
 
-  const handleImage = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!e?.target.files) return;
+  const handleImage = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!e.target.files) return;
     // 이미지 화면에 띄우기
     const newImagesURL = Array.from(
-      e?.target.files,
+      e.target.files,
       (file: Blob | MediaSource) => URL.createObjectURL(file),
     );
     const newList = props.imageList.concat(newImagesURL);
     if (newList.length > 10) {
-      alert('이미지는 10장 이상 추가할 수 없습니다.');
+      alert('이미지는 최대 10장까지 업로드 가능합니다.');
       return;
     }
+    const files = Array.from(e.target.files);
     props.setImageList(newList);
+    props.setImageFiles((prev) => [...prev, ...files]);
   };
 
   return (

--- a/src/hooks/api/useInsight.ts
+++ b/src/hooks/api/useInsight.ts
@@ -13,6 +13,7 @@ import {
 import {
   InsightOGImagePostRequest,
   InsightPostRequest,
+  InsightPostResponse,
   InsightPutRequest,
 } from '@/types/insight';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
@@ -48,9 +49,12 @@ export function usePostInsight() {
 
   return useMutation({
     mutationFn: (data: InsightPostRequest) => postInsight(data),
-    onSuccess: () => {
+    onSuccess: (data: InsightPostResponse) => {
       queryClient.invalidateQueries({ queryKey: ['insight'] });
-      router.replace('/upload/saved');
+      router.replace({
+        pathname: '/upload/saved',
+        query: { insightId: data },
+      });
     },
   });
 }

--- a/src/hooks/api/useInsight.ts
+++ b/src/hooks/api/useInsight.ts
@@ -32,10 +32,13 @@ export function useGetFolderInsight(folderId: number) {
   });
 }
 
-export function usePostImageLink(image: FormData) {
-  return useQuery({
-    queryKey: ['image-link'],
-    queryFn: () => postImage(image),
+export function usePostInsightImage() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: FormData) => postImage(data),
+    onSuccess: () =>
+      queryClient.invalidateQueries({ queryKey: ['insight-image'] }),
   });
 }
 

--- a/src/hooks/api/useInsight.ts
+++ b/src/hooks/api/useInsight.ts
@@ -7,11 +7,11 @@ import {
   getSharedFolder,
   postImage,
   postInsight,
-  postInsightOGImage,
+  getInsightOGImage,
   putInsight,
 } from '@/api/insight';
 import {
-  InsightOGImagePostRequest,
+  InsightOGImageGetRequest,
   InsightPostRequest,
   InsightPostResponse,
   InsightPutRequest,
@@ -73,10 +73,10 @@ export function useGetFolderInsightByTag(folderId: number, tag: string) {
   });
 }
 
-export function usePostInsightOGImage() {
-  return useMutation({
-    mutationFn: (imageData: InsightOGImagePostRequest) =>
-      postInsightOGImage(imageData),
+export function useGetInsightOGImage(url: InsightOGImageGetRequest) {
+  return useQuery({
+    queryKey: ['ogimage'],
+    queryFn: () => getInsightOGImage(url),
   });
 }
 

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -41,11 +41,11 @@ const LinkInput: NextPage = ({}) => {
     // console.log(data?.map((folder) => folder.folderName));
 
     if (imageFiles) {
-      const formData = new FormData();
       imageFiles.forEach((image) => {
+        const formData = new FormData();
         formData.append('image', image);
+        mutate(formData);
       });
-      mutate(formData);
     }
 
     // 인사이트 제목, 요약, 키워드 요청

--- a/src/pages/upload/index.tsx
+++ b/src/pages/upload/index.tsx
@@ -9,6 +9,7 @@ import { getAccessToken } from '@/utils/auth';
 import InputWithTitle from '@/components/common/InputWithTitle';
 import UploadImage from '@/components/folder/UploadImage';
 import OptionalTextarea from '@/components/common/OptionalTextarea';
+import { usePostInsightImage } from '@/hooks/api/useInsight';
 
 const LinkInput: NextPage = ({}) => {
   const router = useRouter();
@@ -18,6 +19,8 @@ const LinkInput: NextPage = ({}) => {
   const [errorText, setErrorText] = useState('');
   const [source, setSource] = useState('');
   const { data } = useGetFolder();
+  const { mutate } = usePostInsightImage();
+  const [imageFiles, setImageFiles] = useState<File[]>([]);
 
   useEffect(() => {
     if (!getAccessToken()) {
@@ -35,7 +38,16 @@ const LinkInput: NextPage = ({}) => {
       alert('링크를 입력해주세요.');
       return;
     }
-    console.log(data?.map((folder) => folder.folderName));
+    // console.log(data?.map((folder) => folder.folderName));
+
+    if (imageFiles) {
+      const formData = new FormData();
+      imageFiles.forEach((image) => {
+        formData.append('image', image);
+      });
+      mutate(formData);
+    }
+
     // 인사이트 제목, 요약, 키워드 요청
     router.push(
       {
@@ -79,7 +91,12 @@ const LinkInput: NextPage = ({}) => {
             value={link}
             onChange={(e) => handleInputLink(e.target.value)}
           />
-          <UploadImage imageList={imageList} setImageList={setImageList} />
+          <UploadImage
+            imageList={imageList}
+            setImageList={setImageList}
+            imageFiles={imageFiles}
+            setImageFiles={setImageFiles}
+          />
           <OptionalTextarea
             bottom={30}
             titleTypo="big"

--- a/src/pages/upload/input-text/index.tsx
+++ b/src/pages/upload/input-text/index.tsx
@@ -76,7 +76,9 @@ const Upload: NextPage = ({}) => {
         insightUrl: String(link),
         insightTitle: result.title,
         insightSummary: String(result.summary),
-        insightMainImage: String(imageList),
+        insightMainImage: String(
+          imageList && imageList.length > 1 ? imageList[0] : imageList,
+        ),
         insightTagList: result.keywords
           ? Array.isArray(result.keywords)
             ? result.keywords

--- a/src/pages/upload/input-text/index.tsx
+++ b/src/pages/upload/input-text/index.tsx
@@ -77,7 +77,7 @@ const Upload: NextPage = ({}) => {
         insightTitle: result.title,
         insightSummary: String(result.summary),
         insightMainImage: String(
-          imageList && imageList.length > 1 ? imageList[0] : imageList,
+          Array.isArray(imageList) ? imageList[0] : imageList,
         ),
         insightTagList: result.keywords
           ? Array.isArray(result.keywords)

--- a/src/pages/upload/input-text/index.tsx
+++ b/src/pages/upload/input-text/index.tsx
@@ -53,7 +53,6 @@ const Upload: NextPage = ({}) => {
   const [remindTerm, setRemindTerm] = useState('');
   const { source, memo, imageList, insightImageList, link, folderNameList } =
     router.query;
-  const [thumbnail, setThumbnail] = useState<string | string[] | undefined>();
   const [isSaving, setIsSaving] = useState(false);
   const { mutate } = usePostInsight();
   const image = useCheckMainImage(imageList, String(link));
@@ -78,7 +77,7 @@ const Upload: NextPage = ({}) => {
         insightUrl: String(link),
         insightTitle: result.title,
         insightSummary: String(result.summary),
-        insightMainImage: String(image),
+        insightMainImage: image ? String(image) : defaultImage.src,
         insightTagList: result.keywords
           ? Array.isArray(result.keywords)
             ? result.keywords
@@ -92,9 +91,6 @@ const Upload: NextPage = ({}) => {
           : [],
         folderName: String(result.folderName),
       });
-      setThumbnail(
-        imageList ? (Array.isArray(imageList) ? imageList[0] : imageList) : [],
-      );
     }
     if (error) {
       console.error(error);
@@ -126,9 +122,9 @@ const Upload: NextPage = ({}) => {
                 <PageIntro>리마인드 카드 설정</PageIntro>
                 <ImageSection>
                   <div className="image-wrapper">
-                    {insightImageList ? (
+                    {image ? (
                       <CardCover
-                        src={String(thumbnail)}
+                        src={image}
                         alt="preview"
                         className="thumbnail"
                       />

--- a/src/pages/upload/input-text/index.tsx
+++ b/src/pages/upload/input-text/index.tsx
@@ -17,6 +17,7 @@ import TagSection from '@/components/upload/TagSection';
 import OptionalTextarea from '@/components/common/OptionalTextarea';
 import FolderSetting from '@/components/upload/FolderSetting';
 import RemindSetting from '@/components/upload/RemindSetting';
+import { useCheckMainImage } from '@/utils/upload';
 
 type aiInput = {
   link: string;
@@ -55,6 +56,7 @@ const Upload: NextPage = ({}) => {
   const [thumbnail, setThumbnail] = useState<string | string[] | undefined>();
   const [isSaving, setIsSaving] = useState(false);
   const { mutate } = usePostInsight();
+  const image = useCheckMainImage(imageList, String(link));
 
   useEffect(() => {
     const newLink = String(link);
@@ -76,9 +78,7 @@ const Upload: NextPage = ({}) => {
         insightUrl: String(link),
         insightTitle: result.title,
         insightSummary: String(result.summary),
-        insightMainImage: String(
-          Array.isArray(imageList) ? imageList[0] : imageList,
-        ),
+        insightMainImage: String(image),
         insightTagList: result.keywords
           ? Array.isArray(result.keywords)
             ? result.keywords

--- a/src/pages/upload/input-text/index.tsx
+++ b/src/pages/upload/input-text/index.tsx
@@ -76,7 +76,7 @@ const Upload: NextPage = ({}) => {
         insightUrl: String(link),
         insightTitle: result.title,
         insightSummary: String(result.summary),
-        insightMainImage: String(imageList?.[0]),
+        insightMainImage: String(imageList),
         insightTagList: result.keywords
           ? Array.isArray(result.keywords)
             ? result.keywords

--- a/src/pages/upload/saved/index.tsx
+++ b/src/pages/upload/saved/index.tsx
@@ -6,31 +6,39 @@ import { NextPage } from 'next';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import { insightData1, insightData2 } from '@/constants/data';
+import { useGetInsight } from '@/hooks/api/useInsight';
+import { Insight } from '@/types/insight';
+import { useEffect, useState } from 'react';
 
 const Saved: NextPage = ({}) => {
   const router = useRouter();
-  const { id, title, summary, image, tagList } = router.query;
-  const cardData = {
-    insightId: Number(id),
-    insightTitle: String(title),
-    insightSummary: String(summary),
-    insightMainImage: image ? String(image) : '/image/defaultImage.jpeg',
-    insightTagList: tagList
-      ? Array.isArray(tagList)
-        ? tagList
-        : [tagList]
-      : [],
-    todayRead: false,
-  };
+  const { insightId } = router.query;
+  const { data, isSuccess } = useGetInsight(Number(insightId));
+  const [insight, setInsight] = useState<Insight>();
+
+  useEffect(() => {
+    if (!isSuccess || !data) return;
+    const { insightTitle, insightMainImage, insightSummary, insightTagList } =
+      data;
+    setInsight({
+      insightId: Number(insightId),
+      insightTitle,
+      insightMainImage,
+      insightSummary,
+      insightTagList,
+    });
+  }, [isSuccess, data, insightId]);
 
   return (
     <NavigationLayout>
       <Wrapper>
         <Header title="저장 완료" />
-        <SummaryInsightCard
-          favicon="/svg/insight-favicon.svg"
-          insightData={cardData}
-        />
+        {insight && (
+          <SummaryInsightCard
+            favicon="/svg/insight-favicon.svg"
+            insightData={insight}
+          />
+        )}
         <div className="blue-text">확인하러 가기</div>
         <HrLine />
         <Title>관련 인사이트 둘러보기</Title>

--- a/src/types/insight.ts
+++ b/src/types/insight.ts
@@ -90,11 +90,7 @@ export type InsightPutRequest = {
   reminderAnswer?: string;
 };
 
-// POST /insight/ogimage/{url}
-export type InsightOGImagePostRequest = {
-  url: string;
-};
+// GET /insight/ogimage
+export type InsightOGImageGetRequest = string;
 
-export type InsightOGImagePostResponse = {
-  insightMainImage: string;
-};
+export type InsightOGImageGetResponse = string;

--- a/src/types/insight.ts
+++ b/src/types/insight.ts
@@ -20,7 +20,7 @@ export type InsightDetail = {
     reminderType: string;
     reminderDay: number[];
   };
-  insightHashTagList: string[];
+  insightTagList: string[];
   insightMainImage: string;
   insightImageList: string[];
 };
@@ -61,7 +61,7 @@ export type InsightPostRequest = {
   folderName: string;
 };
 
-export type InsightPostResponse = Partial<InsightDetail>;
+export type InsightPostResponse = number;
 
 // GET /insight
 export type InsightGetRequest = {

--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -1,0 +1,14 @@
+import { useGetInsightOGImage } from '@/hooks/api/useInsight';
+import { InsightOGImageGetRequest } from '@/types/insight';
+// import defaultImage from '@image/defaultImage.jpeg';
+
+export const useCheckMainImage = (
+  imageList: string[] | string | undefined,
+  link: InsightOGImageGetRequest,
+) => {
+  const { data, isSuccess } = useGetInsightOGImage(link);
+  if (Array.isArray(imageList) && imageList.length > 0) return imageList[0];
+  if (typeof imageList === 'string') return imageList;
+  if (isSuccess) return data;
+  //   return defaultImage;
+};

--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -1,6 +1,5 @@
 import { useGetInsightOGImage } from '@/hooks/api/useInsight';
 import { InsightOGImageGetRequest } from '@/types/insight';
-// import defaultImage from '@image/defaultImage.jpeg';
 
 export const useCheckMainImage = (
   imageList: string[] | string | undefined,
@@ -9,6 +8,5 @@ export const useCheckMainImage = (
   const { data, isSuccess } = useGetInsightOGImage(link);
   if (Array.isArray(imageList) && imageList.length > 0) return imageList[0];
   if (typeof imageList === 'string') return imageList;
-  if (isSuccess) return data;
-  //   return defaultImage;
+  if (isSuccess && data !== 'notExist') return data;
 };


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
#46 

## 예상 리뷰 시간
7min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->

### usePostInsightImage

File[] 에 들어있는 이미지 -> 하나씩 formData로 변환 후 post 요청

### POST 예정인 insight MainImage hook
```javascript
export const useCheckMainImage = (
  imageList: string[] | string | undefined,
  link: InsightOGImageGetRequest,
) => {
  const { data, isSuccess } = useGetInsightOGImage(link);
  if (Array.isArray(imageList) && imageList.length > 0) return imageList[0];
  if (typeof imageList === 'string') return imageList;
  if (isSuccess && data !== 'notExist') return data;
};
```

/upload에서 등록된 이미지, ogimage를 바탕으로 post 보낼 mainImage를 판별하는 훅입니다.
코드와 관련된 4가지 케이스는 아래와 같습니다.

1. 이미지 배열일 경우 : 첫번째 이미지 반환
2. 이미지 string일 경우: 그대로 반환
3. ogimage API 응답이 성공적인 경우 : 응답 데이터 반환
4. 훅 리턴값이 undefined인 경우 : /upload/input-image에서 defaultImage 보여줌

훅의 리턴값을 바탕으로 /upload/input-text 페이지의 하단 버튼을 누르면 해당 이미지와 함께 post 요청 보냅니다.

### /upload/saved 화면 API 연결

* /upload/input-text 에서 API 리턴값으로 받은 insightId -> /upload/saved로 라우팅 시 id 데이터 함께 전달
* 인사이트 상세보기 API (/insight/{insightId} 응답 정보로 보여줌

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->


|1. 등록 이미지 1개|2. 등록 이미지 여러개|3. 등록 이미지X, ogimage O|4. 등록 이미지X, ogimage X, defaultImage 사용|
|:--:|:--:|:--:|:--:|
|![May-06-2024 16-46-48](https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/75911380/0dbe3a25-597c-4e63-b5f3-4d14910c76fa)|![May-06-2024 16-45-03](https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/75911380/e01c9334-cb79-450b-9417-dfc6b852139c)| ![May-06-2024 16-42-49](https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/75911380/e47478a5-1dee-444e-a5e2-3337a5353d8c)|![May-06-2024 16-44-02](https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/75911380/bef04673-0e42-48ca-8b35-fbdaba5cfda6)|



## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->