### PR TITLE
헤더 컴포넌트 재사용성 강화

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -29,8 +29,9 @@ const Header = (props: Props) => {
 };
 
 const Wrapper = styled.div`
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  align-items: center;
   width: 100%;
   padding: 18px 20px 16px;
   height: 52px;
@@ -39,12 +40,15 @@ const Wrapper = styled.div`
     font-size: 20px;
     font-weight: 700;
     color: #1f1f1f;
+    text-align: center;
   }
 
   .right-text {
     font-size: 20px;
     font-weight: 500;
     color: #3184ff;
+    text-align: right;
+    margin-bottom: 0 !important;
   }
 
   .invisible {

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -5,6 +5,7 @@ import BackIcon from '@svg/backspace-icon.svg';
 interface Props {
   title?: string;
   rightText?: string;
+  isNotGoingBack?: boolean;
   onClick?: () => void;
 }
 
@@ -13,7 +14,12 @@ const Header = (props: Props) => {
 
   return (
     <Wrapper>
-      <BackIcon onClick={() => router.back()} />
+      <div>
+        <BackIcon
+          className={props.isNotGoingBack && 'invisible'}
+          onClick={() => router.back()}
+        />
+      </div>
       <div className="title">{props.title}</div>
       <div className="right-text" onClick={props.onClick}>
         {props.rightText}
@@ -39,6 +45,10 @@ const Wrapper = styled.div`
     font-size: 20px;
     font-weight: 500;
     color: #3184ff;
+  }
+
+  .invisible {
+    display: none;
   }
 `;
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
#61 

## 예상 리뷰 시간
2min

## 추가 또는 변경사항
- `<BackIcon />`, `title`, `rightText` 의존성 없이 사용 가능하도록 변경
- 세 구성 요소의 유무에 따라 css 깨짐 현상 발생 해결
- grid로 변경 후 일부 화면에서 `n-th child` 속성의 margin 부여 때문에 깨지던 현상 `!important` 삽입으로 수정

## 스크린샷
- 변경 전
<img width="460" alt="스크린샷 2024-05-13 오전 2 57 34" src="https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/49388937/784ab9c7-0275-4c64-843a-306efa9dad9b">
<img width="460" alt="스크린샷 2024-05-13 오전 2 58 32" src="https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/49388937/e4848383-9624-4fdc-b433-fc5648d8d44c">

- 변경 후
<img width="457" alt="스크린샷 2024-05-13 오전 2 52 19" src="https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/49388937/df032946-fdc4-4f00-b8dc-5da10bf9c051">

<img width="449" alt="스크린샷 2024-05-13 오전 2 52 39" src="https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/49388937/807a6cb5-9d92-4525-a0ea-2c7cbca346f4">

<img width="450" alt="스크린샷 2024-05-13 오전 2 53 07" src="https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/49388937/52b1cd7c-8e3b-4366-a2e6-da24bd78e2a0">

<img width="467" alt="스크린샷 2024-05-13 오전 2 54 31" src="https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/49388937/9425c9ea-a35e-4d24-992f-9f90f474e240">

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->