### PR TITLE
ThemeProvider 디자인 시스템 색상, 타이포 추가

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -5,6 +5,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { AppProps } from 'next/app';
 import { useEffect, useState } from 'react';
 import '@styles/animation.css';
+import { theme } from '@/styles/theme';
+import { ThemeProvider } from 'styled-components';
 
 const queryClient = new QueryClient();
 
@@ -37,14 +39,16 @@ export default function App({ Component, pageProps }: AppProps) {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <GlobalStyles />
-      <MainLayout>
-        <Component
-          {...pageProps}
-          deferredPrompt={deferredPrompt}
-          setDeferredPrompt={setDeferredPrompt}
-        />
-      </MainLayout>
+      <ThemeProvider theme={theme}>
+        <GlobalStyles />
+        <MainLayout>
+          <Component
+            {...pageProps}
+            deferredPrompt={deferredPrompt}
+            setDeferredPrompt={setDeferredPrompt}
+          />
+        </MainLayout>
+      </ThemeProvider>
     </QueryClientProvider>
   );
 }

--- a/src/styles/styled-components.d.ts
+++ b/src/styles/styled-components.d.ts
@@ -1,0 +1,6 @@
+import type { ThemeType } from './theme';
+import 'styled-components';
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends ThemeType {}
+}

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -88,3 +88,5 @@ export const theme = {
     `,
   },
 };
+
+export type ThemeType = typeof theme;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,90 @@
+export const theme = {
+  /**
+   *  색상: palette.primary[500] 또는 palette.folder.blue 로 접근합니다.
+   */
+
+  palette: {
+    primary: {
+      500: '#3184FF',
+      100: '#E9EFFF',
+    },
+    neutral: {
+      500: '#1F1F1F',
+      400: '#989898',
+      300: '#848484',
+      200: '#989898',
+      150: '#E1E1E1',
+      100: '#F4F5F7',
+    },
+    folder: {
+      blue: '#D7EBFF',
+      pink: '#FFE4E9',
+      purple: '#E2D8FF',
+      orange: '#FFE5D7',
+      yellow: '#FFF6C5',
+      green: '#DFF8E1',
+    },
+    system: {
+      warning: '#f1404b',
+      disabled: '#878787',
+      background: '#FBFBFB',
+    },
+  },
+  typo: {
+    Head_24_B: `
+        font-size: 24px;
+        font-weight: 700;
+        line-height: 140%;
+    `,
+    Head_20_B: `
+        font-size: 20px;
+        font-weight: 700;
+        line-height: 140%;
+    `,
+    Head_20_M: `
+        font-size: 20px;
+        font-weight: 500;
+        line-height: 140%;
+    `,
+    Body_18_B: `
+        font-size: 18px;
+        font-weight: 700;
+        line-height: 140%;
+    `,
+    Body_18_R: `
+        font-size: 18px;
+        font-weight: 400;
+        line-height: 140%;
+    `,
+    Body_16_SB: `
+        font-size: 16px;
+        font-weight: 600;
+        line-height: 140%;
+    `,
+    Body_14_B: `
+        font-size: 14px;
+        font-weight: 700;
+        line-height: 140%;
+    `,
+    Body_14_M: `
+        font-size: 14px;
+        font-weight: 500;
+        line-height: 140%;
+    `,
+    Caption_12_B: `
+        font-size: 12px;
+        font-weight: 700;
+        line-height: 140%;
+    `,
+    Caption_12_M: `
+        font-size: 12px;
+        font-weight: 500;
+        line-height: 140%;
+    `,
+    Caption_10_SB: `
+        font-size: 10px;
+        font-weight: 600;
+        line-height: 140%;
+    `,
+  },
+};


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close

## 예상 리뷰 시간
3min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->

* 디자인 시스템 색상 정리
* 디자인 시스템 타이포 정리
  * typo는 font-size, font-weight, line-height 적용했습니다.
  *  **리팩토링 시 꼭!!!! font size, weight, line-height 및 필요 없는 색상 / 폰트 관련 코드 정리 부탁드립다!**

```css
// typo 스타일 적용 시 
${({ theme }) => theme.typo.Caption_10_SB}

// 팔레트 컬러 적용 시
background-color: ${({ theme }) => theme.palette.primary[100]};
```


## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

* Neutral 컬러는 500, 400, 300, 200, 150, 100 으로 접근하면 됩니다.
* primary는 blue, pink, purple, orange, yellow, green 으로 접근하면 됩니다.
<img width="585" alt="image" src="https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/75911380/186693a7-a246-4f27-b8d2-4f24fba56e20">

<img width="668" alt="image" src="https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/75911380/77f5032c-3a0c-4ca9-a12d-5cd5efb9d102">


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->