### PR TITLE
[fix] #79 - 인사이트 저장 시 og Image 적용되도록 변경

### DIFF
--- a/src/hooks/custom/useInsightInput.ts
+++ b/src/hooks/custom/useInsightInput.ts
@@ -27,7 +27,6 @@ export default function useInsightInput(query: ParsedUrlQuery) {
   }: InsightInputQuery = query as InsightInputQuery;
 
   const image = useCheckMainImage(imgURLs, insightUrl);
-
   const [insightInput, setInsightInput] = useState<InsightPostRequest>({
     insightUrl: insightUrl,
     insightTitle: '',
@@ -51,6 +50,7 @@ export default function useInsightInput(query: ParsedUrlQuery) {
       insightSummary: String(result.summary),
       insightTagList: result.keywords ? result.keywords.split(', ') : [],
       folderName: String(result.folderName),
+      insightMainImage: image ?? defaultImage.src,
     });
   };
   return { insightInput, setInsightInput, updateInsightInput };

--- a/src/utils/upload.ts
+++ b/src/utils/upload.ts
@@ -8,11 +8,11 @@ export const useCheckMainImage = (
   const { data, isSuccess } = useGetInsightOGImage(link);
   if (Array.isArray(imageList) && imageList.length > 0) return imageList[0];
   if (typeof imageList === 'string') return imageList;
-  if (isSuccess && data !== 'notExist') return data;
+  if (isSuccess && data !== 'notExist') return data.trim();
 };
 
 export const toArray = (input: string | string[] | undefined) => {
   if (!input) return [];
   if (Array.isArray(input)) return input;
   return [input];
-}
+};


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
#79 

## 예상 리뷰 시간
2 min

## 추가 또는 변경사항
- 인사이트 저장 시 사용자가 이미지를 추가하지 않았고, 입력받은 링크 내 이미지가 있다면 cdn 요청해 받아와 적용하도록 수정
-> 초기 화면 로드 시 ogImage를 요청 중이라 'default image' 로 적용되는데 이후 받아온 이미지를 적용하지 못해서 생긴 문제
-> ai 제목, 요약, 키워드 등을 받아와서 화면을 업데이트할 때 같이 업데이트 하도록 수정

++ 네트워크 탭 상에서 요청한 ogImage cdn 링크 내 공백이 있는 경우가 있어 `trim()` 메서드 통해 공백 제거하도록 코드 추가
<img width="424" alt="스크린샷 2024-06-28 오후 2 50 48" src="https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/49388937/02be81e9-f451-4209-99b0-55fcc8361c19">

## 스크린샷
- 변경 전
![download](https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/49388937/673a8cfe-ebcb-49e2-aae4-d81c2d24df6b)

- 변경 후
![download (1)](https://github.com/9oormthon-univ/2024_BEOTKKOTTHON_TEAM_24_FE/assets/49388937/8cdb8dfb-46de-4509-821a-5779ceebba83)

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->